### PR TITLE
enhancement/fetch id from url

### DIFF
--- a/framework/service/dtq/rockycube/EndpointServices.xml
+++ b/framework/service/dtq/rockycube/EndpointServices.xml
@@ -41,6 +41,7 @@ along with this software (see the LICENSE.md file). If not, see
             type="script"
             location="classpath://service/dtq/rockycube/endpoint/EndpointService.groovy">
         <in-parameters>
+            <parameter name="id" type="String" required="true"/>
             <parameter name="term" type="List" default="[]"/>
             <parameter name="entityName" type="String"/>
             <parameter name="tableName" type="String"/>

--- a/framework/service/dtq/rockycube/EndpointServices.xml
+++ b/framework/service/dtq/rockycube/EndpointServices.xml
@@ -60,6 +60,7 @@ along with this software (see the LICENSE.md file). If not, see
             type="script"
             location="classpath://service/dtq/rockycube/endpoint/EndpointService.groovy">
         <in-parameters>
+            <parameter name="id" type="String" required="true"/>
             <parameter name="term" type="List" default="[]"/>
             <parameter name="entityName" type="String"/>
             <parameter name="tableName" type="String"/>

--- a/framework/service/dtq/rockycube/endpoint/EndpointService.groovy
+++ b/framework/service/dtq/rockycube/endpoint/EndpointService.groovy
@@ -16,7 +16,7 @@ def deleteEntity()
     EndpointServiceHandler ech = new EndpointServiceHandler(args, term, entityName, tableName, failsafe, serviceAllowedOn)
     // ec.logger.debug("Executing deleteEntity method")
     try {
-        return ech.deleteEntityData()
+        return ech.deleteEntityData(id)
     } catch (Exception exc){
         return [result: false, message: "Failed on delete: ${exc.message}"]
     }

--- a/framework/service/dtq/rockycube/endpoint/EndpointService.groovy
+++ b/framework/service/dtq/rockycube/endpoint/EndpointService.groovy
@@ -27,7 +27,7 @@ def updateEntity()
 {
     EndpointServiceHandler ech = new EndpointServiceHandler(args, term, entityName, tableName, failsafe, serviceAllowedOn)
     try {
-        return ech.updateEntityData(data)
+        return ech.updateEntityData(id, data)
     } catch (Exception exc){
         return [result: false, message: "Failed on update: ${exc.message}"]
     }

--- a/framework/src/main/groovy/dtq/rockycube/endpoint/EndpointServiceHandler.groovy
+++ b/framework/src/main/groovy/dtq/rockycube/endpoint/EndpointServiceHandler.groovy
@@ -614,10 +614,18 @@ class EndpointServiceHandler {
         ]
     }
 
-    public HashMap deleteEntityData()
+    public HashMap deleteEntityData(String id)
     {
-        def toDeleteSearch = ec.entity.find(entityName).condition(queryCondition)
-        logger.debug("DELETE: entityName/term: ${entityName}/${queryCondition}")
+        if (StringUtils.isBlank(id))
+        {
+            return [
+                    result: false,
+                    message: 'Id cannot be null or empty'
+            ]
+        }
+
+        def toDeleteSearch = ec.entity.find(entityName).condition("_id", id)
+        logger.debug("DELETE: entityName/term: ${entityName}/\"_id\" = ${id}")
 
         // convert to list for message
         def toDelete = toDeleteSearch.list()

--- a/framework/src/main/groovy/dtq/rockycube/endpoint/EndpointServiceHandler.groovy
+++ b/framework/src/main/groovy/dtq/rockycube/endpoint/EndpointServiceHandler.groovy
@@ -6,6 +6,7 @@ import dtq.rockycube.entity.ConditionHandler
 import dtq.rockycube.entity.EntityHelper
 import dtq.synchro.SynchroMaster
 import dtq.rockycube.GenericUtilities
+import org.apache.commons.lang3.StringUtils
 import org.moqui.Moqui
 import org.moqui.context.ExecutionContext
 import org.moqui.entity.EntityCondition
@@ -767,8 +768,16 @@ class EndpointServiceHandler {
         return this.fetchEntityData_standard()
     }
 
-    public HashMap updateEntityData(HashMap<String, Object> data)
+    public HashMap updateEntityData(String id, HashMap<String, Object> data)
     {
+        if (StringUtils.isBlank(id))
+        {
+            return [
+                    result: false,
+                    message: 'Id cannot be null or empty'
+            ]
+        }
+
         if (data.isEmpty())
         {
             return [
@@ -778,9 +787,9 @@ class EndpointServiceHandler {
         }
 
         def toUpdate = ec.entity.find(entityName)
-                .condition(queryCondition)
+                .condition("_id", id)
                 .forUpdate(true)
-        logger.debug("UPDATE: entityName/term: ${entityName}/${queryCondition}")
+        logger.debug("UPDATE: entityName/term: ${entityName}/\"_id\" = ${id}")
 
         // update record
         return this.updateSingleEntity(toUpdate, data)
@@ -788,7 +797,7 @@ class EndpointServiceHandler {
 
     public HashMap updateEntityData()
     {
-        return updateEntityData(ec.context.data?:[:] as HashMap<String, Object>)
+        return updateEntityData(ec.context.id as String, ec.context.data?:[:] as HashMap<String, Object>)
     }
 
     private HashMap updateSingleEntity(EntityFind toUpdate, HashMap<String, Object> updateData){

--- a/framework/src/main/groovy/dtq/rockycube/entity/ConditionHandler.groovy
+++ b/framework/src/main/groovy/dtq/rockycube/entity/ConditionHandler.groovy
@@ -245,7 +245,7 @@ class ConditionHandler {
         sdf.setLenient(false);
         try {
             sdf.parse(dateStr);
-        } catch (ParseException e) {
+        } catch (ParseException | NullPointerException e) {
             return false;
         }
         return true;


### PR DESCRIPTION
Updated services to get `id` of the updating/deleting object from the URL and find object by the `_id` not by the queryCondition which is composed from the `term` object.